### PR TITLE
Update image fallback

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -121,8 +121,13 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
               ...filtered.map((product) => ListTile(
-                    leading:
-                        Image.network(product.imageUrl, width: 50, height: 50),
+                    leading: Image.network(
+                      product.imageUrl,
+                      width: 50,
+                      height: 50,
+                      errorBuilder: (context, error, stackTrace) =>
+                          const Icon(Icons.broken_image, size: 50),
+                    ),
                     title: Text(product.name),
                     subtitle: Text('\$${product.price.toStringAsFixed(2)}'),
                     onTap: () => Navigator.push(


### PR DESCRIPTION
## Summary
- show a broken image icon when a product image fails to load

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ab8cc24c83339d13bb3c83ba81fe