### PR TITLE
Share ApiClient across services

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,18 +2,26 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'screens/login_screen.dart';
 import 'services/cart_service.dart';
+import 'services/api_client.dart';
+import 'services/auth_service.dart';
 
 void main() {
-  runApp(const MyApp());
+  final client = ApiClient();
+  runApp(MyApp(client: client));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  final ApiClient client;
+  const MyApp({Key? key, required this.client}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => CartService(),
+    return MultiProvider(
+      providers: [
+        Provider<ApiClient>.value(value: client),
+        Provider<AuthService>(create: (_) => AuthService(client)),
+        ChangeNotifierProvider(create: (_) => CartService(client)),
+      ],
       child: MaterialApp(
         title: 'GreenBasket',
         theme: ThemeData(primarySwatch: Colors.green),

--- a/lib/screens/cart_screen.dart
+++ b/lib/screens/cart_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/cart_item.dart';
 import '../services/cart_service.dart';
 import '../services/order_service.dart';
+import '../services/api_client.dart';
 import 'thank_you_screen.dart';
 
 class CartScreen extends StatelessWidget {
@@ -41,7 +42,8 @@ class CartScreen extends StatelessWidget {
                     onPressed: cart.items.isEmpty
                         ? null
                         : () async {
-                            final service = OrderService();
+                            final client = Provider.of<ApiClient>(context, listen: false);
+                            final service = OrderService(client);
                             final order = await service.createOrder('123 Street', 'COD');
                             if (order != null && context.mounted) {
                               Navigator.push(

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import '../models/product.dart';
 import '../services/cart_service.dart';
 import '../services/product_service.dart';
 import '../services/category_service.dart';
+import '../services/api_client.dart';
 import '../models/category.dart';
 import 'cart_screen.dart';
 import 'product_detail.dart';
@@ -17,8 +18,8 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  final ProductService _productService = ProductService();
-  final CategoryService _categoryService = CategoryService();
+  late final ProductService _productService;
+  late final CategoryService _categoryService;
   final TextEditingController _search = TextEditingController();
   late Future<List<Product>> _productsFuture;
   List<Category> _categories = [];
@@ -27,6 +28,9 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   void initState() {
     super.initState();
+    final client = Provider.of<ApiClient>(context, listen: false);
+    _productService = ProductService(client);
+    _categoryService = CategoryService(client);
     _productsFuture = _load();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final cart = Provider.of<CartService>(context, listen: false);

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../services/auth_service.dart';
 import 'home_screen.dart';
 import 'register_screen.dart';
@@ -14,12 +15,12 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   final _username = TextEditingController();
   final _password = TextEditingController();
-  final _auth = AuthService();
   bool _loading = false;
 
   Future<void> _login() async {
     setState(() => _loading = true);
-    final success = await _auth.login(_username.text, _password.text);
+    final auth = Provider.of<AuthService>(context, listen: false);
+    final success = await auth.login(_username.text, _password.text);
     setState(() => _loading = false);
     if (success) {
       Navigator.pushReplacement(

--- a/lib/screens/order_screen.dart
+++ b/lib/screens/order_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../services/order_service.dart';
+import '../services/api_client.dart';
 
 class OrderScreen extends StatefulWidget {
   const OrderScreen({Key? key}) : super(key: key);
@@ -9,12 +11,14 @@ class OrderScreen extends StatefulWidget {
 }
 
 class _OrderScreenState extends State<OrderScreen> {
-  final OrderService _service = OrderService();
+  late final OrderService _service;
   late Future<void> _future;
 
   @override
   void initState() {
     super.initState();
+    final client = Provider.of<ApiClient>(context, listen: false);
+    _service = OrderService(client);
     _future = _service.fetchOrders();
   }
 

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../services/auth_service.dart';
 import 'home_screen.dart';
 
@@ -13,12 +14,12 @@ class _RegisterScreenState extends State<RegisterScreen> {
   final _username = TextEditingController();
   final _email = TextEditingController();
   final _password = TextEditingController();
-  final AuthService _auth = AuthService();
   bool _loading = false;
 
   Future<void> _register() async {
     setState(() => _loading = true);
-    final success = await _auth.register(
+    final auth = Provider.of<AuthService>(context, listen: false);
+    final success = await auth.register(
         _username.text, _email.text, _password.text);
     setState(() => _loading = false);
     if (success) {

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -3,7 +3,12 @@ import 'package:http/http.dart' as http;
 
 class ApiClient {
   static const String baseUrl = 'https://greenbasket-backend.onrender.com';
+  final http.Client _client;
   String? _token;
+
+  ApiClient({http.Client? httpClient}) : _client = httpClient ?? http.Client();
+
+  String? get token => _token;
 
   void updateToken(String? token) {
     _token = token;
@@ -20,14 +25,14 @@ class ApiClient {
   }
 
   Future<dynamic> get(String path) async {
-    final response = await http.get(_uri(path), headers: _headers());
+    final response = await _client.get(_uri(path), headers: _headers());
     _check(response);
     return json.decode(response.body);
   }
 
   Future<dynamic> post(String path, Map<String, dynamic> data) async {
     final response =
-        await http.post(_uri(path), headers: _headers(), body: json.encode(data));
+        await _client.post(_uri(path), headers: _headers(), body: json.encode(data));
     _check(response);
     return json.decode(response.body);
   }

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -2,7 +2,8 @@ import '../models/user.dart';
 import 'api_client.dart';
 
 class AuthService {
-  final ApiClient _client = ApiClient();
+  final ApiClient _client;
+  AuthService(this._client);
   User? _user;
 
   User? get currentUser => _user;

--- a/lib/services/cart_service.dart
+++ b/lib/services/cart_service.dart
@@ -4,7 +4,8 @@ import '../models/product.dart';
 import 'api_client.dart';
 
 class CartService extends ChangeNotifier {
-  final ApiClient _client = ApiClient();
+  final ApiClient _client;
+  CartService(this._client);
   final List<CartItem> _items = [];
 
   List<CartItem> get items => List.unmodifiable(_items);

--- a/lib/services/category_service.dart
+++ b/lib/services/category_service.dart
@@ -2,7 +2,8 @@ import '../models/category.dart';
 import 'api_client.dart';
 
 class CategoryService {
-  final ApiClient _client = ApiClient();
+  final ApiClient _client;
+  CategoryService(this._client);
 
   Future<List<Category>> fetchCategories() async {
     final data = await _client.get('/categories/');

--- a/lib/services/dev_service.dart
+++ b/lib/services/dev_service.dart
@@ -1,7 +1,8 @@
 import 'api_client.dart';
 
 class DevService {
-  final ApiClient _client = ApiClient();
+  final ApiClient _client;
+  DevService(this._client);
 
   Future<dynamic> seedDemoData() async => _client.seed();
 }

--- a/lib/services/order_service.dart
+++ b/lib/services/order_service.dart
@@ -3,7 +3,8 @@ import '../models/backend_order.dart';
 import 'api_client.dart';
 
 class OrderService {
-  final ApiClient _client = ApiClient();
+  final ApiClient _client;
+  OrderService(this._client);
   final List<BackendOrder> _orders = [];
 
   List<BackendOrder> get orders => List.unmodifiable(_orders);

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,7 +1,8 @@
 import 'api_client.dart';
 
 class PaymentService {
-  final ApiClient _client = ApiClient();
+  final ApiClient _client;
+  PaymentService(this._client);
 
   Future<dynamic> initiate(int orderId, double amount) async {
     return _client.initiatePayment(orderId, amount);

--- a/lib/services/product_service.dart
+++ b/lib/services/product_service.dart
@@ -2,7 +2,8 @@ import '../models/product.dart';
 import 'api_client.dart';
 
 class ProductService {
-  final ApiClient _client = ApiClient();
+  final ApiClient _client;
+  ProductService(this._client);
 
   Future<List<Product>> fetchProducts() async {
     final data = await _client.get('/products/');

--- a/test/api_client_test.dart
+++ b/test/api_client_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:greenbasket/services/api_client.dart';
+import 'package:greenbasket/services/auth_service.dart';
+import 'package:greenbasket/services/cart_service.dart';
+import 'package:greenbasket/services/order_service.dart';
+import 'package:greenbasket/models/product.dart';
+
+void main() {
+  test('Cart and order requests include Authorization header after login', () async {
+    final requests = <http.Request>[];
+    var handler = (http.Request req) async {
+      requests.add(req);
+      if (req.url.path == '/auth/login') {
+        return http.Response(json.encode({'access_token': 'token'}), 200);
+      }
+      if (req.url.path == '/users/me') {
+        return http.Response(json.encode({'id': 1, 'username': 'u', 'email': 'e'}), 200);
+      }
+      return http.Response('{}', 200);
+    };
+    final mockClient = MockClient((req) => handler(req));
+
+    final api = ApiClient(httpClient: mockClient);
+    final auth = AuthService(api);
+    final cart = CartService(api);
+    final orders = OrderService(api);
+
+    expect(await auth.login('u', 'p'), isTrue);
+
+    handler = (http.Request req) async {
+      requests.add(req);
+      return http.Response('{}', 200);
+    };
+
+    final product = Product(id: 1, name: 'n', price: 1.0, description: '', imageUrl: '');
+    await cart.add(product);
+    await orders.createOrder('addr', 'COD');
+
+    final authed = requests.where((r) => r.url.path != '/auth/login' && r.url.path != '/users/me');
+    for (final r in authed) {
+      expect(r.headers['Authorization'], 'Bearer token');
+    }
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,11 +7,12 @@
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:greenbasket/main.dart';
+import 'package:greenbasket/services/api_client.dart';
 import 'package:flutter/material.dart';
 
 void main() {
   testWidgets('Login screen loads', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp(client: ApiClient()));
     expect(find.text('Login'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- inject a shared `ApiClient` into all services
- provide `ApiClient`, `AuthService` and `CartService` via `MultiProvider`
- update screens to obtain services via Provider
- allow ApiClient to accept a custom `http.Client`
- add tests verifying auth headers on cart/order requests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b33f57e8833381a0aa9802e6505d