### PR TITLE
Add offline data fallback for guest mode

### DIFF
--- a/lib/services/category_service.dart
+++ b/lib/services/category_service.dart
@@ -5,10 +5,18 @@ class CategoryService {
   final ApiClient _client = ApiClient();
 
   Future<List<Category>> fetchCategories() async {
-    final data = await _client.get('/categories/');
-    return (data as List)
-        .map((e) => Category.fromJson(e as Map<String, dynamic>))
-        .toList();
+    try {
+      final data = await _client.get('/categories/');
+      return (data as List)
+          .map((e) => Category.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } catch (_) {
+      return [
+        Category(id: 1, name: 'Fruits'),
+        Category(id: 2, name: 'Vegetables'),
+        Category(id: 3, name: 'Dairy'),
+      ];
+    }
   }
 
   Future<Category> createCategory(String name) async {

--- a/lib/services/product_service.dart
+++ b/lib/services/product_service.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+
 import '../models/product.dart';
 import 'api_client.dart';
 
@@ -5,17 +8,24 @@ class ProductService {
   final ApiClient _client = ApiClient();
 
   Future<List<Product>> fetchProducts() async {
-    final data = await _client.get('/products/');
-    return (data as List)
-        .map((e) => Product.fromJson(e as Map<String, dynamic>))
-        .toList();
+    try {
+      final data = await _client.get('/products/');
+      return _parseList(data);
+    } catch (_) {
+      return _loadLocalProducts();
+    }
   }
 
   Future<List<Product>> searchProducts(String query) async {
-    final data = await _client.get('/products?search=$query');
-    return (data as List)
-        .map((e) => Product.fromJson(e as Map<String, dynamic>))
-        .toList();
+    try {
+      final data = await _client.get('/products?search=$query');
+      return _parseList(data);
+    } catch (_) {
+      final all = await _loadLocalProducts();
+      return all
+          .where((p) => p.name.toLowerCase().contains(query.toLowerCase()))
+          .toList();
+    }
   }
 
   Future<Product> createProduct(
@@ -28,5 +38,19 @@ class ProductService {
     final data = await _client.addProduct(
         name, description, price, stock, categoryId, imageUrl);
     return Product.fromJson(data as Map<String, dynamic>);
+  }
+
+  List<Product> _parseList(dynamic data) {
+    return (data as List)
+        .map((e) => Product.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<Product>> _loadLocalProducts() async {
+    final jsonStr = await rootBundle.loadString('assets/products.json');
+    final data = json.decode(jsonStr) as List;
+    return data
+        .map((e) => Product.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 }


### PR DESCRIPTION
## Summary
- make product service load demo data from assets/products.json when API calls fail
- provide default categories when the API isn't reachable

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671ccc9e8c8333830f55f2b18dd36a