### PR TITLE
Fix syntax errors in HomeScreen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -213,22 +213,29 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
               ),
               Padding(
-  padding: const EdgeInsets.symmetric(vertical: 8),
-  child: SizedBox(
-    height: 150,
-    child: PageView(
-      children: [
-        'https://via.placeholder.com/400x150.png?text=Offer+1',
-        'https://via.placeholder.com/400x150.png?text=Offer+2',
-        'https://via.placeholder.com/400x150.png?text=Offer+3',
-      ].map((url) => ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: Image.network(url, fit: BoxFit.cover),
-          ))
-        .toList(),
-    ),
-  ),
-),
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: SizedBox(
+                  height: 150,
+                  child: PageView(
+                    children: [
+                      'https://via.placeholder.com/400x150.png?text=Offer+1',
+                      'https://via.placeholder.com/400x150.png?text=Offer+2',
+                      'https://via.placeholder.com/400x150.png?text=Offer+3',
+                    ]
+                        .map(
+                          (url) => ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: Image.network(
+                              url,
+                              fit: BoxFit.cover,
+                              width: double.infinity,
+                            ),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+              ),
               SizedBox(
                 height: 100,
                 child: ListView(


### PR DESCRIPTION
## Summary
- correct widget hierarchy for the page view offer slider

## Testing
- `flutter build web --base-href="/greenbasket-customer-app/"` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68675334204083338716e0f2e23ba9c1