### PR TITLE
Enable go_router navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'package:go_router/go_router.dart';
 import 'screens/login_screen.dart';
 import 'screens/register_screen.dart';
 import 'screens/main_screen.dart';
 import 'screens/offline_screen.dart';
+import 'screens/product_detail.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'services/cart_service.dart';
 import 'services/auth_service.dart';
@@ -47,20 +49,26 @@ class MyApp extends StatelessWidget {
               if (snapshot.hasData && snapshot.data == ConnectivityResult.none) {
                 return const MaterialApp(home: OfflineScreen());
               }
-              return MaterialApp(
+              final _router = GoRouter(
+                routes: [
+                  GoRoute(path: '/', builder: (_, __) => const LoginScreen()),
+                  GoRoute(path: '/home', builder: (_, __) => const MainScreen()),
+                  GoRoute(path: '/register', builder: (_, __) => const RegisterScreen()),
+                  GoRoute(
+                    path: '/product/:id',
+                    builder: (c, s) => ProductDetail(id: int.parse(s.params['id']!)),
+                  ),
+                ],
+              );
+              return MaterialApp.router(
                 title: 'GreenBasket',
                 theme: ThemeData(
                   colorScheme:
                       ColorScheme.fromSeed(seedColor: const Color(0xFF6AA84F)),
                   textTheme: GoogleFonts.poppinsTextTheme(),
                 ),
-                home: auth.currentUser != null
-                    ? const MainScreen()
-                    : const LoginScreen(),
-                routes: {
-                  '/login': (_) => const LoginScreen(),
-                  '/register': (_) => const RegisterScreen(),
-                },
+                routeInformationParser: _router.routeInformationParser,
+                routerDelegate: _router.routerDelegate,
               );
             },
           );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -14,6 +14,7 @@ import '../services/wishlist_service.dart';
 import '../widgets/empty_view.dart';
 import '../widgets/error_view.dart';
 import 'product_detail.dart';
+import 'package:go_router/go_router.dart';
 import 'cart_screen.dart';
 import 'order_screen.dart';
 
@@ -332,8 +333,7 @@ class _HomeScreenState extends State<HomeScreen> {
           children: [
             Expanded(
               child: GestureDetector(
-                onTap: () => Navigator.push(context,
-                    MaterialPageRoute(builder: (_) => ProductDetail(product: p))),
+                onTap: () => context.push('/product/${p.id}'),
                 child: Image.network(
                   p.imageUrl,
                   fit: BoxFit.cover,

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
 import '../services/auth_service.dart';
 import '../services/cart_service.dart';
-import 'main_screen.dart';
 import 'forgot_password_screen.dart';
 import 'otp_screen.dart';
 
@@ -42,10 +42,9 @@ class _LoginScreenState extends State<LoginScreen> {
     if (result == AuthResult.success) {
       final cart = context.read<CartService>();
       await cart.load();
-      Navigator.pushReplacement(
-          context, MaterialPageRoute(builder: (_) => const MainScreen()));
+      if (mounted) context.go('/home');
     } else if (result == AuthResult.unauthorized) {
-      Navigator.pushReplacementNamed(context, '/register');
+      if (mounted) context.go('/register');
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Invalid credentials')),
@@ -124,19 +123,14 @@ class _LoginScreenState extends State<LoginScreen> {
                       child: const Text('Login with OTP'),
                     ),
                     ElevatedButton(
-                      onPressed: () => Navigator.pushNamed(context, '/register'),
+                      onPressed: () => context.push('/register'),
                       style: ElevatedButton.styleFrom(
                         backgroundColor: Colors.grey.shade300,
                       ),
                       child: const Text('Register'),
                     ),
                     TextButton(
-                      onPressed: () {
-                        Navigator.pushReplacement(
-                            context,
-                            MaterialPageRoute(
-                                builder: (_) => const MainScreen()));
-                      },
+                      onPressed: () => context.go('/home'),
                       child: const Text('Continue as Guest'),
                     ),
                   ],

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
 import '../services/auth_service.dart';
 import '../services/address_service.dart';
 import '../models/address.dart';
@@ -191,11 +192,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                 const SizedBox(width: 8),
                                 Expanded(
                                   child: ElevatedButton(
-                                    onPressed: () {
-                                      _auth.logout();
-                                      Navigator.pushReplacementNamed(
-                                          context, '/login');
-                                    },
+                                  onPressed: () {
+                                    _auth.logout();
+                                    context.go('/');
+                                  },
                                     child: const Text('Logout'),
                                   ),
                                 ),

--- a/lib/screens/register_screen.dart
+++ b/lib/screens/register_screen.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
 import '../services/auth_service.dart';
-import 'main_screen.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({Key? key}) : super(key: key);
@@ -41,8 +41,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
         _username.text, _email.text, _password.text);
     setState(() => _loading = false);
     if (ok && mounted) {
-      Navigator.pushReplacement(
-          context, MaterialPageRoute(builder: (_) => const MainScreen()));
+      context.go('/home');
     } else if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Registration failed')),

--- a/lib/services/product_service.dart
+++ b/lib/services/product_service.dart
@@ -77,6 +77,15 @@ class ProductService {
     return _cache!;
   }
 
+  Future<Product> fetchProduct(int id) async {
+    if (_auth.currentUser == null) {
+      final list = await _loadLocal();
+      return list.firstWhere((p) => p.id == id);
+    }
+    final data = await _client.get('/products/$id');
+    return Product.fromJson(data as Map<String, dynamic>);
+  }
+
   List<Product> _parseList(dynamic data) {
     return (data as List)
         .map((e) => Product.fromJson(e as Map<String, dynamic>))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   shimmer: ^3.0.0
   flutter_local_notifications: ^16.3.0
   url_launcher: ^6.2.3
+  go_router: ^13.0.1
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- add `go_router` dependency
- switch main app to `MaterialApp.router`
- implement routes with `GoRouter`
- update Login, Register and Profile flows to use `context.go`/`context.push`
- enable product detail navigation via route with dynamic id
- support fetching single product in `ProductService`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869821b5bb08333b076c4b34bc77e93