### PR TITLE
Fix blank page by setting base href

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="/">
+  <base href="/greenbasket-customer-app/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
## Summary
- fix base href in `index.html` so site loads correctly on GitHub Pages

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699f27ff3c8333b7634d0aa8f9fb81