### PR TITLE
Fix base href placeholder in index.html

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="${FLUTTER_BASE_HREF}">
+  <base href="$FLUTTER_BASE_HREF">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
## Summary
- fix base href placeholder expected by Flutter build

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a1f7af688333930312ecf98f85a0