### PR TITLE
Fix wishlist provider null check

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,7 +38,11 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => AuthService()),
         ChangeNotifierProxyProvider<AuthService, WishlistService>(
           create: (ctx) => WishlistService(ctx.read<AuthService>()),
-          update: (ctx, auth, prev) => prev!..updateAuth(auth),
+          update: (ctx, auth, prev) {
+            final service = prev ?? WishlistService(auth);
+            service.updateAuth(auth);
+            return service;
+          },
         ),
       ],
       child: Consumer<AuthService>(


### PR DESCRIPTION
## Summary
- handle null previous value in ChangeNotifierProxyProvider for WishlistService to prevent runtime null check error

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c01e849c8333a88f4c491c8cfdeb